### PR TITLE
feat: Add macOS support to Makefile and update README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 .ONESHELL:
-.RECIPEPREFIX = >
+UNAME_S := $(shell uname -s)
 
+# IF Darwin
+ifeq ($(UNAME_S),Darwin)
+COMPILER=acme --format cbm -v3
+CRUNCHER=./bin/exomizer sfx 0x801 -x3 -C
+else
 COMPILER=bin/acme --format cbm -v3
 CRUNCHER=bin/exomizer sfx 0x801 -x3 -C
+endif
 DISKTOOL=c1541
-EMULATOR=x64sc -silent
+EMULATOR=x64sc -silent -seed 42 +confirmonexit
 SOURCES=$(wildcard src/*.asm)
 TARGET=c64-base
 TARGET_PRG=$(TARGET).prg
@@ -13,17 +19,17 @@ TARGET_DISK=$(TARGET).d64
 all: compile crunch disk run
 
 compile:
-> $(COMPILER) -o $(TARGET_PRG) $(SOURCES)
+	$(COMPILER) -o $(TARGET_PRG) $(SOURCES)
 
 crunch:
-> $(CRUNCHER) $(TARGET_PRG) -o $(TARGET_PRG)
+	$(CRUNCHER) $(TARGET_PRG) -o $(TARGET_PRG)
 
 disk:
-> $(DISKTOOL) -format $(TARGET),42 d64 $(TARGET_DISK) -attach $(TARGET_DISK) -write $(TARGET_PRG) $(TARGET)
+	$(DISKTOOL) -format $(TARGET),42 d64 $(TARGET_DISK) -attach $(TARGET_DISK) -write $(TARGET_PRG) $(TARGET)
 
 run:
-> $(EMULATOR) ${TARGET_DISK}
+	$(EMULATOR) ${TARGET_DISK}
 
 clean:
-> $(RM) $(TARGET_PRG)
-> $(RM) $(TARGET_DISK)
+	$(RM) $(TARGET_PRG)
+	$(RM) $(TARGET_DISK)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,25 @@
 # c64-base
+
 Toolkit for cross compiling MOS Technology 6502 assembly code for the Commodore 64.
 
 ## Requirements
-* make
-* vice
+
+- make
+- vice
+
+### Install on MacOS:
+
+`brew install acme vice`
+
+`git clone https://bitbucket.org/magli143/exomizer.git`
+
+`(cd exomizer/src/; make; cp exomizer ../../bin/)`
 
 ## Usage
+
 `make`
 
 ## Notes
-* `acme` version 0.97 and `exomizer` version 3.1.3b0 was built from source using `gcc` version 14.2.1 on Arch Linux.
-* `c1541` and `x64sc` version 3.9 is part of [Vice](https://vice-emu.sourceforge.io/).
+
+- `acme` version 0.97 and `exomizer` version 3.1.3b0 was built from source using `gcc` version 14.2.1 on Arch Linux.
+- `c1541` and `x64sc` version 3.9 is part of [Vice](https://vice-emu.sourceforge.io/).


### PR DESCRIPTION
- Introduced macOS-specific handling in the Makefile:
  - Added detection for macOS using `uname -s`.
  - Updated COMPILER and CRUNCHER paths for macOS.
  - Adjusted the EMULATOR settings to include a consistent seed and confirmation on exit.

- Updated README.md instructions:
  - Added installation steps for `acme` and `exomizer` on macOS using Homebrew and manual compilation.
  - Organized requirements list into a more visually distinct format.

- Replaced recursive `>` recipe prefix with tab character for Makefile consistency and POSIX compatibility.